### PR TITLE
Fix typos and grammar

### DIFF
--- a/src/content/ABOUT_US.md
+++ b/src/content/ABOUT_US.md
@@ -4,20 +4,20 @@ We are a group of software developers and designers who build software together.
 No, we are an open-source organization that spends our free time building products,
 software, and libraries from start to finish.
 
-## Why do we do this
+## Why we do this
 We love software, love building things, so why not do it as a group.
-We are a mixed group of people, some have a lot of experience, 
-others are just starting and want some more experience to put on their resume. 
+We are a mixed group of people; some have a lot of experience, 
+others are just starting out and want more experience to put on their resume. 
 Either way, we are here to help one another and make sure we build something worth showing.
 
 ## Our story
 Back in December 2020, a 
 <a href="https://www.urbandictionary.com/define.php?term=padawan" target="_blank">young padawan</a>
-wrote a message on the local meetup group slack (Turku Loves Frotnend)
+wrote a message on the local meetup group slack (Turku Loves Frontend)
 > Hello everyone, I got this idea in my head that I want to start a hobby project, 
 > don’t know what todo! Don’t really care what we use it can be everything from Go to Perl, 
 > don’t really care just want to do a hobby project with some people. Who would be interested 
 > in building something together?
 
-That message got a few replies, and we become **Turku Forge**! 
-We are a new organisation, and we are still figuring what our next steps are.
+That message got a few replies, and we became **Turku Forge**! 
+We are a new organization still figuring what our next steps are.


### PR DESCRIPTION
There could be some padding on the _Our Active Projects_ title. Also, the black background is filled both from `projects` and the `team` sections. The sticky `div` in teams should be removed, or does it have some hidden purpose?

![image](https://user-images.githubusercontent.com/17124245/109420938-cd0f5700-79dd-11eb-955f-418b439accec.png)
![image](https://user-images.githubusercontent.com/17124245/109421120-ac93cc80-79de-11eb-9d4d-ce83bbf079a0.png)


